### PR TITLE
Additional Item Rarity Color Check

### DIFF
--- a/common/src/main/java/einstein/subtle_effects/ticking/tickers/entity/ItemRarityTicker.java
+++ b/common/src/main/java/einstein/subtle_effects/ticking/tickers/entity/ItemRarityTicker.java
@@ -75,6 +75,11 @@ public class ItemRarityTicker extends EntityTicker<ItemEntity> {
             Component hoverName = stack.getHoverName();
             TextColor baseColor = hoverName.getStyle().getColor();
             List<TextColor> colors = new ArrayList<>(hoverName.getSiblings().stream().map(component -> component.getStyle().getColor()).filter(Objects::nonNull).toList());
+
+            Component displayName = stack.getDisplayName();
+            TextColor dispColor = displayName.getStyle().getColor();
+            if (baseColor == null && dispColor != null && !dispColor.equals(WHITE_TEXT)) baseColor = dispColor;
+
             boolean usesSingleColor = colors.isEmpty() || !ITEMS.itemRarity.mixedColorName; // isEmpty needs to be stored before adding the baseColor to the 'colors' list
 
             if (baseColor != null) {


### PR DESCRIPTION
This PR adds a small change/addition to how `ItemRarityTicker.getItemNameColors()` locates colors on an `ItemStack`'s name, which then determines the particle color output.

---------------------------------------------------------

For context as to why I made this PR, I recently wrote loader-agnostic Rarity code for a mod called Appledog, and soon planned to integrate it into a library project I contribute to, RunicLib. This code "simulated" rarities by mixing into `ItemStack`'s `getDisplayName()` and `getTooltipLines()` functions; this allows it to render with a unique color instead of a `ChatFormatting` preset.

As a stress test, I ran Appledog alongside several mods, including Subtle Effects. However, when dropping an Appledog-related item with the unique rarity, the particles rendered using `ChatFormatting.RED`, which was the fallback color for the custom Rarity. This can be seen in the image below alongside several other modded rarities:

<img width="1353" height="549" alt="image" src="https://github.com/user-attachments/assets/e114e70d-ce24-4bd1-8a70-49d955a13589" />

The fix to this was a lazy, but simple one that should (likely) catch any edge case like this: if `baseColor` is `null`, the code will then read the display name of the stack instead, and see if it can apply the color from there. Unfortunately, this fix will only work when `particleColorType = "NAME_COLOR"` in the config file, but it at the very least still allows it to render the proper color in some form.

Below is what the Appledog-related items look like with the fix applied (tested on both NF and Fabric):
(*NOTE: All other items in the previous screenshot were checked seperately - no changes to their color or any weird issues were found.*)

BEFORE (brighter, incorrect red):
<img width="124" height="186" alt="image" src="https://github.com/user-attachments/assets/a5ce281d-0a7a-4024-aa3a-e6a7a8383a66" />


AFTER (darker, proper red):
<img width="122" height="208" alt="image" src="https://github.com/user-attachments/assets/3b881f26-4820-4d57-90ce-b8d27bba16cc" />