### PR TITLE
[1.20.1] Bump minimum forge version for changes in cad2bd6

### DIFF
--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -21,7 +21,7 @@ issueTrackerURL="https://github.com/MincraftEinstein/SubtleEffects/issues"
 [[dependencies.subtle_effects]]
     modId = "forge"
     mandatory = true
-    versionRange = "[47.0.0,)"
+    versionRange = "[47.4.14,)"
     ordering = "NONE"
     side = "BOTH"
 


### PR DESCRIPTION
Commit cad2bd6 mixes into the entity fluid pushing calc optimization I backported from 1.21.11, which is made available in 47.4.14 at minimum, and so your mod now has that version as a minimum requirement.

Errors such as <https://gnomebot.dev/paste/mclogs/PvlbbZ9> happen when running in versions below the threshold.

Also closes #212